### PR TITLE
Fix Python dependency updating bug

### DIFF
--- a/jobs/update-dependencies/update-python-dependencies.sh
+++ b/jobs/update-dependencies/update-python-dependencies.sh
@@ -21,7 +21,7 @@ updatePackage() {
 	git checkout -b "$branchname" 2> /dev/null
 	# Make the upgrade in the file, pinning the package to the new version,
 	# leaving whitespace (spaces and tabs) and comments alone
-	sed -i.bak -e "s/^$package[^ #	]*/$package==$version/" "$reqFile"
+	sed -i.bak -e "s/^$package==[^ #	]*/$package==$version/" "$reqFile"
 	# Add, commit, and (try to) push the change
 	git add "$reqFile"
 	git commit -m "Update $package to $version in $reqFile" > /dev/null 2>&1
@@ -102,7 +102,7 @@ updateRepo() {
 			fi
 			# Skip lines marked with a comment containing "skip"
 			# Otherwise, update the package in the current file
-			if grep "^$package.*#.*skip" "$reqFile" > /dev/null;
+			if grep "^$package==.*#.*skip" "$reqFile" > /dev/null;
 			then
 				echo ">Skipping $package"
 			else


### PR DESCRIPTION
The replacement of packages in Python requirements file would replace
packages that contained the names of other packages with the shorter
package name, because it wasn't matching the end of the name. Example:

django-allauth==0.27.0
django-allauth-2fa==0.2

Would be replaced with:

django-allauth==0.28.0
django-allauth==0.28.0

The same logic in a different place would cause a similar error with a
"skip" comment for a package with a long name skipping updating packages
with shorter names that are substrings of the longer package name.

Change searches to require "==" immediately after the end of the package
name.

(note: this isn't tested on AWS)

Fix #20.